### PR TITLE
Remove links to slideroom, close the Awards for this year

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ header: false
 footer_partner: false
 ---
 <!-- Section: Intro -->
-<section class="section-slab section-hero">  
+<section class="section-slab section-hero">
   <video autoplay loop poster="{{ site.baseurl }}/images/video-bg-new.jpg" id="bgvid">
     <!-- <source src="polina.webm" type="video/webm"> -->
     <source src="{{ site.baseurl }}/images/city_blurry_new.mp4" type="video/mp4">
@@ -17,12 +17,11 @@ footer_partner: false
     </div>
     <div class="grid-item width-two-thirds">
         <p>
-          The Code for America Technology Awards recognize outstanding products and implementations of government technology. Winners will be announced on stage at the <a href="https://www.codeforamerica.org/summit/" ga('send', 'event', 'Homepage: Summit button click', 'Summit button in hero', 1);>Code for America Summit</a>, September 30 &ndash; October 2 in Oakland, CA. 
+          The Code for America Technology Awards recognize outstanding products and implementations of government technology. Winners will be announced on stage at the <a href="https://www.codeforamerica.org/summit/" ga('send', 'event', 'Homepage: Summit button click', 'Summit button in hero', 1);>Code for America Summit</a>, September 30 &ndash; October 2 in Oakland, CA.
         </p>
-        <p><strong>Applications are open from June 23 through July 13, 2015.</strong></p>
+        <p><strong>Applications for the 2015 awards are now closed.</strong></p>
         <div class="button-group">
-          <a href="{{ site.baseurl }}/signup" class="button button-white" onclick="ga('send', 'event', 'Homepage: Interest signup button click', 'Interest form in hero', 1);">Sign up for updates</a>
-          <a href="https://codeforamerica.slideroom.com/#/permalink/program/25604/jRmWKgzhzX" target="_blank" class="button" onclick="ga('send', 'event', 'Homepage: Apply button click', 'Apply button in hero', 1);">Apply now</a>
+          <a href="{{ site.baseurl }}/signup" class="button" onclick="ga('send', 'event', 'Homepage: Interest signup button click', 'Interest form in hero', 1);">Stay up-to-date with the awards</a>
         </div>
     </div>
   </div>
@@ -42,8 +41,7 @@ footer_partner: false
       <div class="step-copy">
         <h4>You fill out the simple application</h4>
         <p>It's free to apply. Just answer some questions about your technology.</p>
-        <p class="note">Applications open June 23-July 13</p>
-        <p class="note"><a href="https://codeforamerica.slideroom.com/#/permalink/program/25604/jRmWKgzhzX" target="_blank" onclick="ga('send', 'event', 'Homepage: Apply button click', 'Apply button in How It Works section', 1);">Apply now</a></p>
+        <p class="note">Applications are now closed</p>
 
       </div>
     </div>
@@ -94,7 +92,7 @@ footer_partner: false
     </div>
     <div class="grid-item width-one-half">
       <h4>Training</h4>
-      <p>Winners are invited to an afternoon at Google Campus where they will have the opportunity to partake in mentor sessions with Googlers and hear from speakers on topics relevant to government technology. 
+      <p>Winners are invited to an afternoon at Google Campus where they will have the opportunity to partake in mentor sessions with Googlers and hear from speakers on topics relevant to government technology.
 	  </p>
     </div>
   </div>
@@ -104,11 +102,11 @@ footer_partner: false
 <section class="[ section-slab section-slab-color ] section-apply words-center">
 	<div class="grid-box">
 		<div class="grid-item width-one-whole grid-item-isolate words-center">
-			<h1>Ready to start your application?</h1>
-      <a href="https://codeforamerica.slideroom.com/#/permalink/program/25604/jRmWKgzhzX" target="_blank" class="button" onclick="ga('send', 'event', 'Homepage: Apply button click', 'Apply reminder in middle of page');">Apply now</a>
-    
+			<h1>Applications are now closed</h1>
+      <a href="{{ site.baseurl }}/signup" target="_blank" class="button" onclick="ga('send', 'event', 'Homepage: Interest signup button click', 'Interest signup in middle of page');">Stay up-to-date with the awards</a>
 		</div>
 	</div>
+  <!--
   <div class="grid-box">
     <div class="grid-item width-one-whole">
       <h3>Get your questions answered</h3>
@@ -120,6 +118,7 @@ footer_partner: false
       </ul>
     </div>
   </div>
+  -->
 </section>
 
 <!-- Section: Selection Criteria -->


### PR DESCRIPTION
@dharmishta I removed all the links to the Slideroom since it's now closed, and changed all our call to action spots to sign up for the mailing list if they're interested in more info.

We can tweak language in the future for CTA to indicate they can sign up for updates about who wins, and also get notified when next year's applications open.
